### PR TITLE
adding support for streaming results via data channels

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,5 +1,11 @@
 LIVEKIT_WS_URL=
-LIVEKIT_TOKEN_FOR_USER=
-LIVEKIT_TOKEN_FOR_DIRECTAI=
 DIRECTAI_CLIENT_ID=
 DIRECTAI_CLIENT_SECRET=
+
+# NOTE: ensure all tokens point to the same room!
+# if you just want to try streaming to DirectAI
+LIVEKIT_TOKEN_FOR_USER=
+LIVEKIT_TOKEN_FOR_DIRECTAI=
+
+# if you also want to receive results via WebRTC
+LIVEKIT_TOKEN_FOR_RESULTS=

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .env
+*venv*
+*.pyc
+*__pycache__/

--- a/README.md
+++ b/README.md
@@ -4,13 +4,17 @@
 
 Run [DirectAI](https://directai.io) on a [LiveKit](https://livekit.io) stream and see the results in real time!
 
-We will open a browser using LiveKit's [meet](https://meet.livekit.io) product and have DirectAI join the room! We'll then build on-the-fly detectors matching your descriptions and track objects in the video feed in real time!
+We will open a browser using LiveKit's [meet](https://meet.livekit.io) product and have DirectAI join the room! We'll then build on-the-fly object detectors matching your descriptions and track objects in the video feed in real time!
 
 ## Getting Started
 - You'll need DirectAI credentials to use the API - generate those by heading to our [landing page](https://directai.io) and logging in/signing up via the "Get API Access" button. New users get their first **10k streaming images free**!
 - Generate two LiveKit tokens for the same room, one for a bot powered by DirectAI and one for your user. Check out Liveit's instructions on [Generating Keys & Tokens](https://docs.livekit.io/cloud/keys-and-tokens/). Note that you can also generate them via [Livekit's CLI](https://github.com/livekit/livekit-cli).
+- Optionally, create a third token for the same room, which will be used to receive real-time results via the WebRTC data channel. (Results can also be received via a webhook.)
 - Run `cp .env.template .env` and populate the env variables.
 - Run `pip install -r requirements.txt` in your environment (e.g. conda, venv) of choice.
 
 ## Running It
-Run `python stream_script.py` to start a LiveKit room and get started with object tracking.
+Run `python stream_script.py` to start a LiveKit room and get started with object tracking. If you included a token in `LIVEKIT_TOKEN_FOR_RESULTS`, you'll also see 
+
+## Stopping It
+Just press CTRL-C to stop the process!

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ We will open a browser using LiveKit's [meet](https://meet.livekit.io) product a
 - Run `pip install -r requirements.txt` in your environment (e.g. conda, venv) of choice.
 
 ## Running It
-Run `python stream_script.py` to start a LiveKit room and get started with object tracking. If you included a token in `LIVEKIT_TOKEN_FOR_RESULTS`, you'll also see 
+Run `python stream_script.py` to start a LiveKit room and get started with object tracking. If you included a token in `LIVEKIT_TOKEN_FOR_RESULTS`, you'll also see real-time object tracking results returned to the client via WebRTC data channels, along with a measure of latency from DirectAI's backend receiving the frame from LiveKit to the client receiving the tracked object results. We would expect this latency to be <200ms.
 
 ## Stopping It
 Just press CTRL-C to stop the process!

--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ We will open a browser using LiveKit's [meet](https://meet.livekit.io) product a
 ## Getting Started
 - You'll need DirectAI credentials to use the API - generate those by heading to our [landing page](https://directai.io) and logging in/signing up via the "Get API Access" button. New users get their first **10k streaming images free**!
 - Generate two LiveKit tokens for the same room, one for a bot powered by DirectAI and one for your user. Check out Liveit's instructions on [Generating Keys & Tokens](https://docs.livekit.io/cloud/keys-and-tokens/). Note that you can also generate them via [Livekit's CLI](https://github.com/livekit/livekit-cli).
-- Optionally, create a third token for the same room, which will be used to receive real-time results via the WebRTC data channel. (Results can also be received via a webhook.)
+- Optionally, create a third token for the same room, which will be used to receive real-time results via the WebRTC data channel. (Results can also be received via a webhook.) Note that if you don't want the results listener to be visible, make sure to issue a LiveKit token that is marked as belonging to an invisible/hidden attendee.
 - Run `cp .env.template .env` and populate the env variables.
 - Run `pip install -r requirements.txt` in your environment (e.g. conda, venv) of choice.
 
 ## Running It
-Run `python stream_script.py` to start a LiveKit room and get started with object tracking. If you included a token in `LIVEKIT_TOKEN_FOR_RESULTS`, you'll also see real-time object tracking results returned to the client via WebRTC data channels, along with a measure of latency from DirectAI's backend receiving the frame from LiveKit to the client receiving the tracked object results. We would expect this latency to be <200ms.
+Run `python stream_script.py` to start a LiveKit room and get started with object tracking. If you include a token in LIVEKIT_TOKEN_FOR_RESULTS, you'll see printed in the terminal real-time object tracking results returned to the client via WebRTC data channels. In addition, you'll see a measure of latency from when DirectAI received the frame from LiveKit to when the client received the tracking results from the data channel. We would expect this latency to be <200ms.
 
 ## Stopping It
 Just press CTRL-C to stop the process!

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ We will open a browser using LiveKit's [meet](https://meet.livekit.io) product a
 - You'll need DirectAI credentials to use the API - generate those by heading to our [landing page](https://directai.io) and logging in/signing up via the "Get API Access" button. New users get their first **10k streaming images free**!
 - Generate two LiveKit tokens for the same room, one for a bot powered by DirectAI and one for your user. Check out Liveit's instructions on [Generating Keys & Tokens](https://docs.livekit.io/cloud/keys-and-tokens/). Note that you can also generate them via [Livekit's CLI](https://github.com/livekit/livekit-cli).
 - Optionally, create a third token for the same room, which will be used to receive real-time results via the WebRTC data channel. (Results can also be received via a webhook.) Note that if you don't want the results listener to be visible, make sure to issue a LiveKit token that is marked as belonging to an invisible/hidden attendee.
+- Note that LiveKit token permission checking isn't robust so without correct permissions there may be silent failures. The easiest path would be to ensure that each token has permission to subscribe to and publish tracks, and also to access the data channel.
 - Run `cp .env.template .env` and populate the env variables.
 - Run `pip install -r requirements.txt` in your environment (e.g. conda, venv) of choice.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 python-dotenv==1.0.0
 requests==2.31.0
+livekit==0.7.1
+livekit-api==0.4.1

--- a/result_pipe.py
+++ b/result_pipe.py
@@ -1,0 +1,106 @@
+from livekit import rtc 
+from typing import Literal, Optional, Dict, Any, Callable
+from dataclasses import dataclass, field
+import uuid
+from datetime import datetime
+import json
+import time
+
+
+
+
+CLASSIFIER_RESULT_TOPIC = "classifier-result-topic"
+DETECTOR_RESULT_TOPIC = "detector-result-topic"
+TRACKER_RESULT_TOPIC = "tracker-result-topic"
+TOPICS_LIST = [CLASSIFIER_RESULT_TOPIC, DETECTOR_RESULT_TOPIC, TRACKER_RESULT_TOPIC]
+TOPICS_TYPE = Literal[CLASSIFIER_RESULT_TOPIC, DETECTOR_RESULT_TOPIC, TRACKER_RESULT_TOPIC]
+
+
+async def connect_to_room(url, token):
+    room = rtc.Room()
+    await room.connect(url, token)
+    return room
+
+
+def get_unique_id():
+    return str(uuid.uuid4())
+
+
+# an implementation of receiving results via data channel
+# following LiveKit's ChatManager interface
+
+@dataclass
+class ModelResult:
+    message: Optional[str] = None
+    id: str = field(default_factory=get_unique_id)
+    timestamp: datetime = field(default_factory=datetime.now)
+    deleted: bool = field(default=False)
+
+    # These fields are not part of the wire protocol. They are here to provide
+    # context for the application.
+    participant: Optional[rtc.room.Participant] = None
+    is_local: bool = field(default=False)
+
+    @classmethod
+    def from_jsondict(cls, d: Dict[str, Any]) -> "ModelResult":
+        # older version of the protocol didn't contain a message ID, so we'll create one
+        id = d.get("id") or get_unique_id()
+        timestamp = datetime.now()
+        if d.get("timestamp"):
+            timestamp = datetime.fromtimestamp(d.get("timestamp", 0) / 1000.0)
+        msg = cls(
+            id=id,
+            timestamp=timestamp,
+        )
+        msg.update_from_jsondict(d)
+        return msg
+
+    def update_from_jsondict(self, d: Dict[str, Any]) -> None:
+        self.message = d.get("message")
+        self.deleted = d.get("deleted", False)
+
+    def asjsondict(self):
+        """Returns a JSON serializable dictionary representation of the message."""
+        d = {
+            "id": self.id,
+            "message": self.message,
+            "timestamp": int(self.timestamp.timestamp() * 1000),
+        }
+        if self.deleted:
+            d["deleted"] = True
+        return d
+
+
+class ResultPipe(rtc._event_emitter.EventEmitter[Literal["message_received",]]):
+    def __init__(self, room: rtc.Room):
+        super().__init__()
+        self.room = room
+        self.lp = room.local_participant
+    
+        room.on("data_received", self._on_data_received)
+    
+    def close(self):
+        self.room.off("data_received", self._on_data_received)
+    
+    async def send_message(self, message: str, topic: TOPICS_TYPE):
+        datum = ModelResult(message=message, is_local=True, participant=self.lp)
+        await self.lp.publish_data(
+            payload=json.dumps(datum.asjsondict()),
+            kind=rtc.DataPacketKind.KIND_RELIABLE,
+            topic=topic,
+        )
+        return datum
+    
+    def _on_data_received(self, pkt: rtc.DataPacketKind):
+        if pkt.topic in TOPICS_LIST:
+            print(f"data received by {self.lp.name} with topic {pkt.topic}")
+            result = ModelResult.from_jsondict(json.loads(pkt.data))
+            result_message_json = json.loads(result.message)
+            print(result_message_json)
+            backend_received_frame_timestamp = result_message_json["metadata"]["timestamp"]
+            latency = time.time() - backend_received_frame_timestamp
+            print(f"Latency from DirectAI backend receiving frame to receiving results via data channel: {latency}")
+            self.emit("message_received", result)
+            # # #
+            # add other logic here
+            # # #

--- a/stream_script.py
+++ b/stream_script.py
@@ -10,13 +10,12 @@ load_dotenv()
 
 LIVEKIT_TOKEN_FOR_DIRECTAI = os.getenv("LIVEKIT_TOKEN_FOR_DIRECTAI")
 LIVEKIT_TOKEN_FOR_USER = os.getenv("LIVEKIT_TOKEN_FOR_USER")
-LIVEKIT_TOKEN_FOR_RESULTS = os.getenv("LIVEKIT_TOKEN_FOR_RESULTS", None)
+LIVEKIT_TOKEN_FOR_RESULTS = os.getenv("LIVEKIT_TOKEN_FOR_RESULTS", '')
 LIVEKIT_WS_URL = os.getenv("LIVEKIT_WS_URL")
 DIRECTAI_CLIENT_ID = os.getenv("DIRECTAI_CLIENT_ID")
 DIRECTAI_CLIENT_SECRET = os.getenv("DIRECTAI_CLIENT_SECRET")
 
-# DIRECTAI_BASE_URL = "https://api.free.directai.io"
-DIRECTAI_BASE_URL = "http://100.66.146.61:8000"
+DIRECTAI_BASE_URL = "https://api.free.directai.io"
 
 
 def assemble_webrtc_config():
@@ -103,7 +102,7 @@ def assemble_webrtc_config():
     }
     
     webrtc_stream_tracker_config = {
-        "return_via_data_channel": LIVEKIT_TOKEN_FOR_RESULTS is not None,
+        "return_via_data_channel": LIVEKIT_TOKEN_FOR_RESULTS != '',
         "webhook_url": None,
         "webrtc_url": LIVEKIT_WS_URL,
         "token": LIVEKIT_TOKEN_FOR_DIRECTAI,
@@ -154,7 +153,7 @@ async def main():
     result_pipe = None
     
     try:
-        if LIVEKIT_TOKEN_FOR_RESULTS is not None:
+        if LIVEKIT_TOKEN_FOR_RESULTS != '':
             # only create livekit dependency if we need it
             from result_pipe import ResultPipe, connect_to_room
             


### PR DESCRIPTION
We want to enable real-time communication with the DirectAI backend. To do that, we can send tracking results to the client directly via WebRTC data channels, avoiding the use of webhooks.